### PR TITLE
try to fix flaky

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/method/MethodWriter2Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/MethodWriter2Test.java
@@ -10,6 +10,8 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -65,7 +67,8 @@ public class MethodWriter2Test {
         if (allowThrough) {
             assertTrue(mr.readOne());
             assertEquals(1, output.size());
-            assertEquals(argument.expected(), output.toString());
+            HashSet<String> expecteds=new HashSet<String>(Arrays.asList(argument.expected().split(";")));
+            assertTrue(expecteds.contains(output.toString()));
             assertFalse(mr.readOne());
         } else {
             assertFalse(mr.readOne());
@@ -82,7 +85,37 @@ public class MethodWriter2Test {
                         "  fr: NaN,\n" +
                         "  mins: 0\n" +
                         "}\n" +
-                        "]]";
+                        "]];" +
+                        "[funding[!net.openhft.chronicle.wire.method.Funding {\n" +
+                        "  symbol: 0,\n" +
+                        "  mins: 0,\n" +
+                        "  fr: NaN\n" +
+                        "}\n" +
+                        "]];" +
+                        "[funding[!net.openhft.chronicle.wire.method.Funding {\n" +
+                        "  fr: NaN,\n" +
+                        "  symbol: 0,\n" +
+                        "  mins: 0\n" +
+                        "}\n" +
+                        "]];" +
+                        "[funding[!net.openhft.chronicle.wire.method.Funding {\n" +
+                        "  fr: NaN,\n" +
+                        "  mins: 0,\n" +
+                        "  symbol: 0\n" +
+                        "}\n" +
+                        "]];" +
+                        "[funding[!net.openhft.chronicle.wire.method.Funding {\n" +
+                        "  mins: 0,\n" +
+                        "  symbol: 0,\n" +
+                        "  fr: NaN\n" +
+                        "}\n" +
+                        "]];" +
+                        "[funding[!net.openhft.chronicle.wire.method.Funding {\n" +
+                        "  mins: 0,\n" +
+                        "  fr: NaN,\n" +
+                        "  symbol: 0\n" +
+                        "}\n" +
+                        "]]" ;
             }
 
             @Override


### PR DESCRIPTION
Test **MethodWriter2Test.allowThrough** compares the result which is generated from an **java.util.ArrayList** by function **toString** with a hardcoded string. But the result is somehow nondetermistic and makes the test flaky. To fix it, I try to enumerate all possibilities of the expected outputs, record them in a list and assert the list contains the actual result.